### PR TITLE
Plug up all non-void functions without return statements 

### DIFF
--- a/pc/debugger/BrrContextMenu.cpp
+++ b/pc/debugger/BrrContextMenu.cpp
@@ -116,7 +116,7 @@ uint16_t get_voice_srcn_addr(uint8_t voice)
 int BrrContextMenu::write_brr_to_file_callback(void *data)
 {
 	uintptr_t brr_addr = (uintptr_t) data;
-	write_brr_to_file( (Brr *) &::IAPURAM[brr_addr]);
+	return write_brr_to_file( (Brr *) &::IAPURAM[brr_addr]);
 }
 
 int BrrContextMenu::write_sti_to_file_callback(void *data)
@@ -146,6 +146,7 @@ int BrrContextMenu::write_sti_to_file_callback(void *data)
 	}
 
 	sample.brr = NULL; // stop destructor from freeing that mem
+	return 0;
 }
 
 #include "BaseD.h"

--- a/pc/debugger/Menu_Bar.cpp
+++ b/pc/debugger/Menu_Bar.cpp
@@ -374,10 +374,12 @@ int Menu_Bar::About_Context::clicked_patreon(void *nada)
 {
   DEBUGLOG("CLICKED PATREON\n");
   openUrl(PATREON_URL);
+  return 0;
 }
 
 int Menu_Bar::About_Context::clicked_merch(void *nada)
 {
   DEBUGLOG("CLICKED MERCH\n");
   openUrl(MERCH_URL);
+  return 0;
 }

--- a/pc/debugger/content_areas/Dsp_Window.cpp
+++ b/pc/debugger/content_areas/Dsp_Window.cpp
@@ -764,7 +764,7 @@ int Dsp_Window::receive_event(SDL_Event &ev)
     {
       default:break;
     }
-    return;
+    return 0;
   }
 
   dblclick::check_event(&ev);
@@ -1276,12 +1276,12 @@ int Dsp_Window::receive_event(SDL_Event &ev)
     case SDL_MOUSEBUTTONDOWN:           
       {
         if (screw_clickable.check_mouse_and_execute(ev.button.x, ev.button.y))
-          return;
+          return 0;
         for (int i=0; i < NUM_TIMERS; i++)
         {
           timers.num = i;
           if (timers.label[i].check_mouse_and_execute(ev.button.x, ev.button.y))
-            return;
+            return 0;
         }
 				/* NOTE: Add code here to check for clicks over DIR entries */
         for (int i=0; i < NUM_DIR_ENTRIES_DISPLAYED; i++)
@@ -1291,7 +1291,7 @@ int Dsp_Window::receive_event(SDL_Event &ev)
 					      dir_rects[i].check_mouse_and_execute(ev.button.x, ev.button.y) ) ||
 					     ( ev.button.button == SDL_BUTTON_LEFT &&
 					      loop_clickable[i].clickable_text.check_mouse_and_execute(ev.button.x, ev.button.y)) )
-            return;
+            return 0;
         }
         for (int i=0; i < MAX_VOICES; i++)
         {
@@ -1305,6 +1305,7 @@ int Dsp_Window::receive_event(SDL_Event &ev)
       default:
       break;
   }
+  return 0;
 }
 
 int Dsp_Window::dir_rect_clicked(void *idx)
@@ -1327,4 +1328,5 @@ int Dsp_Window::dir_rect_clicked(void *idx)
 
 	::brrcontext.menu.preload(mouse::x, mouse::y);
 	::brrcontext.menu.activate();
+	return 0;
 }

--- a/pc/debugger/content_areas/Instrument_Window.cpp
+++ b/pc/debugger/content_areas/Instrument_Window.cpp
@@ -550,6 +550,7 @@ int Instrument_Window::receive_event(SDL_Event &ev)
     default:
     break;
   }
+  return 0;
 }
 
 void Instrument_Window::set_voice(unsigned char v)

--- a/pc/debugger/content_areas/Main_Window.cpp
+++ b/pc/debugger/content_areas/Main_Window.cpp
@@ -175,7 +175,7 @@ int Main_Window::receive_event(SDL_Event &ev)
     {
       default:break;
     }
-    return;
+    return 0;
   }
   check_quit(ev);
 
@@ -891,6 +891,7 @@ int Main_Window::receive_event(SDL_Event &ev)
       default:
       break;
   }
+  return 0;
 }
 
 void Main_Window::run()

--- a/pc/shared/Experience.h
+++ b/pc/shared/Experience.h
@@ -5,5 +5,5 @@ struct Experience
   virtual void run() {};
   virtual void one_time_draw() {}
   virtual void draw() {};
-  virtual int receive_event(SDL_Event &ev) {};
+  virtual int receive_event(SDL_Event &ev) {return 0;};
 };

--- a/pc/shared/SdlNfd.cpp
+++ b/pc/shared/SdlNfd.cpp
@@ -15,6 +15,8 @@ int SdlNfd::init(SDL_Window *win)
     return -2; // already loaded*/
 
   _sdlWindow = win;
+
+  return 0;
 }
 
 

--- a/pc/shared/gui/MouseCursors.cpp
+++ b/pc/shared/gui/MouseCursors.cpp
@@ -492,7 +492,7 @@ void MouseCursors::prev()
   set_cursor(index);
 }
 
-int MouseCursors::handle_event(const SDL_Event &ev)
+void MouseCursors::handle_event(const SDL_Event &ev)
 {
   BmpCursorAni::handle_event(ev);
   MouseTextureAni::handle_event(ev);

--- a/pc/shared/gui/MouseCursors.h
+++ b/pc/shared/gui/MouseCursors.h
@@ -135,7 +135,7 @@ struct MouseCursors
 	void next();
 	void prev();
 
-  int handle_event(const SDL_Event &ev);
+  void handle_event(const SDL_Event &ev);
   void draw_aux();
 
 private:

--- a/pc/shared/gui/Spc_Export_Window.cpp
+++ b/pc/shared/gui/Spc_Export_Window.cpp
@@ -26,6 +26,7 @@ Spc_Export_Window::~Spc_Export_Window()
 int Spc_Export_Window::init()
 {
   // Prepare SPC memory area for export
+  return 0;
 }
 
 void Spc_Export_Window::show()
@@ -151,7 +152,7 @@ int Spc_Export_Window::receive_event(SDL_Event &ev)
     case SDL_MOUSEBUTTONDOWN:
     {
       if (export_button.check_mouse_and_execute(mouse::prescaled_x, mouse::prescaled_y))
-        return;
+        return 0;
       //if (r) return r;
     } break;
 

--- a/pc/shared/gui/Tab.cpp
+++ b/pc/shared/gui/Tab.cpp
@@ -7,6 +7,7 @@ bool Tab::check_mouse_and_execute(int x, int y, void *newdata/*=NULL*/)
 {
   if (enabled)
     return Clickable_Rect::check_mouse_and_execute(x,y,newdata);
+  else {return false;}
 }
 
 int Tab::horiz_pixel_length()

--- a/pc/shared/gui/Text_Edit_Rect.cpp
+++ b/pc/shared/gui/Text_Edit_Rect.cpp
@@ -103,6 +103,7 @@ static inline int check_dblclick(const SDL_Event &ev, Text_Edit_Rect *ter)
       break;
     default:break;
   }
+  return 0;
 }
 
 void Text_Edit_Rect::stop_editing(Text_Edit_Rect *ter/*=cur_editing_ter*/)
@@ -244,6 +245,7 @@ int Text_Edit_Rect::clicked_callback(void *data)
     SDL_StopTextInput();
     Text_Edit_Rect::cursor.stop_timer();
   }
+  return 0;
 }
 
 void Text_Edit_Rect::one_time_draw(SDL_Surface *screen)

--- a/pc/shared/windows/Options_Window/Audio_Options.cpp
+++ b/pc/shared/windows/Options_Window/Audio_Options.cpp
@@ -96,6 +96,7 @@ int Audio_Options::BufferSize::inc(void *b)
     ::player->sample_frame_size *= 2;
     ::player->init(::player->sample_rate, Audio::Devices::selected_audio_out_dev);
   }
+  return 0;
 }
 
 int Audio_Options::BufferSize::dec(void *b)
@@ -106,6 +107,7 @@ int Audio_Options::BufferSize::dec(void *b)
     ::player->sample_frame_size /= 2;
     ::player->init(::player->sample_rate, Audio::Devices::selected_audio_out_dev);
   }
+  return 0;
 }
 
 void Audio_Options::preload(SDL_Rect *rect)

--- a/pc/shared/windows/Options_Window/Audio_Options.cpp
+++ b/pc/shared/windows/Options_Window/Audio_Options.cpp
@@ -11,7 +11,6 @@ int Audio_Options::Context::change_audio_out_device(void *item)
   SDL_Log("change_audio_out_device, %s", itemp->clickable_text.str);
   if (ao->openDeviceonClick)
     ::player->init(::player->sample_rate, itemp->clickable_text.str);
-
   return 0;
 }
 
@@ -189,4 +188,5 @@ int Audio_Options::receive_event(SDL_Event &ev)
 
     default:break;
   }
+  return 0;
 }

--- a/pc/tracker/BpmSpdAddWidget.cpp
+++ b/pc/tracker/BpmSpdAddWidget.cpp
@@ -112,6 +112,7 @@ int BpmSpdAddWidget::handle_event(const SDL_Event &ev)
 
   add_incbtn.check_event(ev);
   add_decbtn.check_event(ev);
+  return 0;
 }
 
 //void BpmSpdAddWidget::one_time_draw(SDL_Surface *screen/*=::render->screen*/)
@@ -148,6 +149,7 @@ int BpmSpdAddWidget::incbpm(void *bsaw)
   BpmSpdAddWidget *b = (BpmSpdAddWidget *)bsaw;
   b->tracker->song.settings.inc_bpm();
   b->updatebpm();
+  return 0;
 }
 
 int BpmSpdAddWidget::decbpm(void *bsaw)
@@ -155,6 +157,7 @@ int BpmSpdAddWidget::decbpm(void *bsaw)
   BpmSpdAddWidget *b = (BpmSpdAddWidget *)bsaw;
   b->tracker->song.settings.dec_bpm();
   b->updatebpm();
+  return 0;
 }
 
 int BpmSpdAddWidget::incspd(void *bsaw)
@@ -162,6 +165,7 @@ int BpmSpdAddWidget::incspd(void *bsaw)
   BpmSpdAddWidget *b = (BpmSpdAddWidget *)bsaw;
   b->tracker->song.settings.inc_spd();
   b->updatespd();
+  return 0;
 }
 
 int BpmSpdAddWidget::decspd(void *bsaw)
@@ -169,16 +173,19 @@ int BpmSpdAddWidget::decspd(void *bsaw)
   BpmSpdAddWidget *b = (BpmSpdAddWidget *)bsaw;
   b->tracker->song.settings.dec_spd();
   b->updatespd();
+  return 0;
 }
 
 int BpmSpdAddWidget::incadd(void *bsaw)
 {
   BpmSpdAddWidget *b = (BpmSpdAddWidget *)bsaw;
   b->pep->inc_addval();
+  return 0;
 }
 
 int BpmSpdAddWidget::decadd(void *bsaw)
 {
   BpmSpdAddWidget *b = (BpmSpdAddWidget *)bsaw;
   b->pep->dec_addval();
+  return 0;
 }

--- a/pc/tracker/ChunkLoader.cpp
+++ b/pc/tracker/ChunkLoader.cpp
@@ -232,6 +232,7 @@ size_t VersionChunkLoader::save(SDL_RWops *file)
   SDL_RWseek(file, chunksize_location, RW_SEEK_SET);
   SDL_RWwrite(file, &chunklen, 2, 1);
   SDL_RWseek(file, chunkend_location, RW_SEEK_SET);
+  return 0;
 }
 
 size_t VersionChunkLoader::load(SDL_RWops *file, size_t chunksize)
@@ -376,4 +377,5 @@ size_t VersionChunkLoader::load(SDL_RWops *file, size_t chunksize)
       maxread += subchunksize;
     }
   }
+  return 0;
 }

--- a/pc/tracker/InstrumentEditor.cpp
+++ b/pc/tracker/InstrumentEditor.cpp
@@ -436,6 +436,7 @@ int InstrumentEditor::handle_event(const SDL_Event &ev)
     if (adsrpanel.check_event(ev) >= ADSR::Context_Menus::ATTACK_CHANGED)
       *instrpanel->instruments[0].metadata.changed = true;
   }
+  return 0;
 }
 
 void InstrumentEditor::draw(SDL_Surface *screen/*=::render->screen*/)
@@ -502,6 +503,7 @@ int InstrumentEditor::incsrcn(void *i)
   {
     ::tracker->renderCurrentInstrument();
   }
+	return 0;
 }
 
 int InstrumentEditor::decsrcn(void *i)
@@ -528,6 +530,7 @@ int InstrumentEditor::decsrcn(void *i)
   {
     ::tracker->renderCurrentInstrument();
   }
+	return 0;
 }
 
 int InstrumentEditor::incvol(void *i)
@@ -544,6 +547,7 @@ int InstrumentEditor::incvol(void *i)
     auto vol = ie->instrpanel->instruments[ie->instrpanel->currow].vol;
     apuinstr->vol = vol;
   }
+  return 0;
 }
 
 int InstrumentEditor::decvol(void *i)
@@ -560,6 +564,7 @@ int InstrumentEditor::decvol(void *i)
     auto vol = ie->instrpanel->instruments[ie->instrpanel->currow].vol;
     apuinstr->vol = vol;
   }
+  return 0;
 }
 
 int InstrumentEditor::incpan(void *i)
@@ -575,6 +580,7 @@ int InstrumentEditor::incpan(void *i)
     int8_t pan = curinst->pan;
     apuinstr->pan = pan;
   }
+  return 0;
 }
 
 int InstrumentEditor::decpan(void *i)
@@ -590,6 +596,7 @@ int InstrumentEditor::decpan(void *i)
     int8_t pan = curinst->pan;
     apuinstr->pan = pan;
   }
+  return 0;
 }
 
 int InstrumentEditor::incfinetune(void *i)
@@ -606,6 +613,7 @@ int InstrumentEditor::incfinetune(void *i)
     int8_t ft = curinst->finetune;
     apuinstr->finetune = ft;
   }
+  return 0;
 }
 
 int InstrumentEditor::decfinetune(void *i)
@@ -622,6 +630,7 @@ int InstrumentEditor::decfinetune(void *i)
     int8_t ft = curinst->finetune;
     apuinstr->finetune = ft;
   }
+  return 0;
 }
 
 InstrumentEditor::Tabs::Tabs(InstrumentEditor *ie) :
@@ -672,6 +681,7 @@ int InstrumentEditor::Tabs::switchto_adsr(void *i)
   ie->tabs.vol.active = false;
   ie->tabs.pan.active = false;
   Tracker::prerenders.insert((DrawRenderer *)&ie->adsrpanel);
+  return 0;
 }
 
 int InstrumentEditor::Tabs::switchto_vol(void *i)
@@ -681,6 +691,7 @@ int InstrumentEditor::Tabs::switchto_vol(void *i)
   ie->tabs.vol.active = true;
   ie->tabs.pan.active = false;
   Tracker::prerenders.erase((DrawRenderer *)&ie->adsrpanel);
+  return 0;
 }
 
 int InstrumentEditor::Tabs::switchto_pan(void *i)
@@ -690,4 +701,5 @@ int InstrumentEditor::Tabs::switchto_pan(void *i)
   ie->tabs.vol.active = false;
   ie->tabs.pan.active = true;
   Tracker::prerenders.erase((DrawRenderer *)&ie->adsrpanel);
+  return 0;
 }

--- a/pc/tracker/Instrument_Panel.cpp
+++ b/pc/tracker/Instrument_Panel.cpp
@@ -218,6 +218,7 @@ int Instrument_Panel::event_handler(const SDL_Event &ev)
   savebtn.check_event(ev);
   dupbtn.check_event(ev);
   zapbtn.check_event(ev);
+  return 0;
 }
 
 void Instrument_Panel::set_currow(int c)

--- a/pc/tracker/Instruments.cpp
+++ b/pc/tracker/Instruments.cpp
@@ -273,6 +273,7 @@ size_t InstrumentChunkLoader::load(SDL_RWops *file, size_t chunksize)
       maxread += subchunksize;
     }
   }
+  return maxread;
 }
 
 /* Write the chunk for particular instrument indexed by i */
@@ -343,6 +344,7 @@ size_t InstrumentChunkLoader::save(SDL_RWops *file, int i)
   SDL_RWseek(file, chunksize_location, RW_SEEK_SET);
   SDL_RWwrite(file, &chunklen, 2, 1);
   SDL_RWseek(file, chunkend_location, RW_SEEK_SET);
+  return 0;
 }
 
 /* TODO: integrate chunklen (featured below) into the ChunkLoader class, and have
@@ -357,6 +359,7 @@ size_t InstrumentChunkLoader::save(SDL_RWops *file)
     if (instruments[i] != ::Instrument()) // empty instrument
       save(file, i);
   }
+  return 0;
 }
 
 size_t InstrumentChunkLoader::save(SDL_RWops *file, struct Instrument *instr)
@@ -365,6 +368,7 @@ size_t InstrumentChunkLoader::save(SDL_RWops *file, struct Instrument *instr)
   instruments = instr;
   save(file, 0);
   instruments = backup;
+  return 0;
 }
 
 /////////////////// INSTRUMENT FILE LOADER //////////////////
@@ -400,6 +404,7 @@ size_t InstrumentFileLoader::save(SDL_RWops *file)
   vcl->save(file);  // version
   scl->save(file, 0);  // samples
   icl->save(file, 0);  // instruments
+  return 0;
 }
 
 InstrumentFileLoader::ret_t InstrumentFileLoader::load(SDL_RWops *file)

--- a/pc/tracker/Menu_Bar.cpp
+++ b/pc/tracker/Menu_Bar.cpp
@@ -23,11 +23,13 @@ Menu_Bar::~Menu_Bar()
 int Menu_Bar::Edit_Context::copy(void *data)
 {
   // STUB
+  return 0;
 }
 
 int Menu_Bar::Edit_Context::paste(void *data)
 {
   // STUB
+  return 0;
 }
 
 int Menu_Bar::Edit_Context::open_options_window(void *data)
@@ -146,6 +148,7 @@ int Menu_Bar::File_Context::new_song(void *data)
 	::tracker->song.patseq.num_entries = 1;
 	::tracker->song.patseq.sequence[0] = 0;
 	::tracker->song.patseq.patterns[0].used = 1;
+	return 0;
 }
 
 int Menu_Bar::File_Context::open_song(void *data)
@@ -507,12 +510,14 @@ int Menu_Bar::About_Context::clicked_patreon(void *nada)
 {
   DEBUGLOG("CLICKED PATREON\n");
   openUrl(PATREON_URL);
+  return 0;
 }
 
 int Menu_Bar::About_Context::clicked_merch(void *nada)
 {
   DEBUGLOG("CLICKED MERCH\n");
   openUrl(MERCH_URL);
+  return 0;
 }
 
 int Menu_Bar::About_Context::clicked_soundcloud(void *nada)

--- a/pc/tracker/Pattern.cpp
+++ b/pc/tracker/Pattern.cpp
@@ -378,6 +378,7 @@ size_t PatternChunkLoader::load(SDL_RWops *file, size_t chunksize)
       maxread += subchunksize;
     }
   }
+  return maxread;
 }
 
 size_t PatternChunkLoader::save(SDL_RWops *file)
@@ -487,6 +488,7 @@ size_t PatternChunkLoader::save(SDL_RWops *file)
     SDL_RWwrite(file, &chunklen, 2, 1);
     SDL_RWseek(file, chunkend_location, RW_SEEK_SET);
   }
+  return 0;
 }
 
 PatternSequencerChunkLoader::PatternSequencerChunkLoader(struct PatternSequencer *patseq) :
@@ -569,6 +571,7 @@ size_t PatternSequencerChunkLoader::load(SDL_RWops *file, size_t chunksize)
       maxread += subchunksize;
     }
   }
+  return 0;
 }
 
 size_t PatternSequencerChunkLoader::save(SDL_RWops *file)
@@ -602,6 +605,7 @@ size_t PatternSequencerChunkLoader::save(SDL_RWops *file)
   SDL_RWseek(file, chunksize_location, RW_SEEK_SET);
   SDL_RWwrite(file, &chunklen, 2, 1);
   SDL_RWseek(file, chunkend_location, RW_SEEK_SET);
+  return 0;
 }
 
 
@@ -907,6 +911,7 @@ int PatSeqPanel::event_handler(const SDL_Event &ev)
 	patlen_incbtn.check_event(ev);
 	patlen_decbtn.check_event(ev);
 
+  return 0;
 }
 
 void PatSeqPanel::one_time_draw(SDL_Surface *screen/*=::render->screen*/)
@@ -1270,6 +1275,7 @@ int PatSeqPanel::inc_patlen(void *bsaw)
 	//DEBUGLOG("inc_patlen; ");
 	::tracker->inc_patlen();
 	b->update_patlen();
+	return 0;
 }
 
 int PatSeqPanel::dec_patlen(void *bsaw)
@@ -1277,6 +1283,7 @@ int PatSeqPanel::dec_patlen(void *bsaw)
 	PatSeqPanel *b = (PatSeqPanel *)bsaw;
 	::tracker->dec_patlen();
 	b->update_patlen();
+	return 0;
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -1917,6 +1924,7 @@ int PatternEditorPanel::event_handler(const SDL_Event &ev)
     } break;
     default:break;
   }
+  return 0;
 }
 
 #define q(n) case SDLK_ ## n : \

--- a/pc/tracker/SampleEditor.cpp
+++ b/pc/tracker/SampleEditor.cpp
@@ -125,6 +125,7 @@ int SampleEditor::handle_event(const SDL_Event &ev)
 
   finetune_incbtn.check_event(ev);
   finetune_decbtn.check_event(ev);
+  return 0;
 }
 
 void SampleEditor::draw(SDL_Surface *screen/*=::render->screen*/)
@@ -190,6 +191,7 @@ int SampleEditor::incloop(void *i)
 
 	ie->update_loop();
   loopHook(&::tracker->main_window.samplepanel);
+	return 0;
 }
 
 int SampleEditor::decloop(void *i)
@@ -200,6 +202,7 @@ int SampleEditor::decloop(void *i)
 
 	ie->update_loop();
   loopHook(&::tracker->main_window.samplepanel);
+	return 0;
 }
 
 
@@ -210,6 +213,7 @@ int SampleEditor::incfinetune(void *i)
   Sample *s = &::tracker->song.samples[::tracker->main_window.samplepanel.currow];
   s->inc_finetune();
   ie->update_finetune();
+  return 0;
 }
 
 int SampleEditor::decfinetune(void *i)
@@ -218,4 +222,5 @@ int SampleEditor::decfinetune(void *i)
 	Sample *s = &::tracker->song.samples[::tracker->main_window.samplepanel.currow];
 	s->dec_finetune();
   ie->update_finetune();
+  return 0;
 }

--- a/pc/tracker/Samples.cpp
+++ b/pc/tracker/Samples.cpp
@@ -239,7 +239,7 @@ size_t SampleChunkLoader::load(SDL_RWops *file, size_t chunksize)
               instr_srcn = i; // mark for the instrument file loader :O
               // skip the rest of thos whole chunk and return
               SDL_RWseek(file, chunksize - maxread, RW_SEEK_CUR);
-              return;
+              return 0;
             }
           }
 
@@ -259,7 +259,7 @@ size_t SampleChunkLoader::load(SDL_RWops *file, size_t chunksize)
           {
             // skip the rest of thos whole chunk and return
             SDL_RWseek(file, chunksize - maxread, RW_SEEK_CUR);
-            return;
+            return 0;
           }
         }
 

--- a/pc/tracker/Samples.cpp
+++ b/pc/tracker/Samples.cpp
@@ -306,6 +306,7 @@ size_t SampleChunkLoader::load(SDL_RWops *file, size_t chunksize)
       maxread += subchunksize;
     }
   }
+  return maxread;
 }
 
 size_t SampleChunkLoader::save(SDL_RWops *file, int i)
@@ -376,6 +377,7 @@ size_t SampleChunkLoader::save(SDL_RWops *file, int i)
   SDL_RWwrite(file, &chunklen, 2, 1);
 
   SDL_RWseek(file, chunkend_location, RW_SEEK_SET);
+  return 0;
 }
 
 size_t SampleChunkLoader::save(SDL_RWops *file)
@@ -386,6 +388,7 @@ size_t SampleChunkLoader::save(SDL_RWops *file)
     if (samples[i].brr != NULL)
       save(file, i);
   }
+  return 0;
 }
 
 size_t SampleChunkLoader::save(SDL_RWops *file, struct Sample *s)
@@ -394,4 +397,5 @@ size_t SampleChunkLoader::save(SDL_RWops *file, struct Sample *s)
   samples = s;
   save(file, 0);
   samples = backup;
+  return 0;
 }

--- a/pc/tracker/Song.cpp
+++ b/pc/tracker/Song.cpp
@@ -86,6 +86,7 @@ size_t SongFileLoader::save(SDL_RWops *file)
   icl->save(file);  // instruments
   pcl->save(file);  // patterns
   pscl->save(file); // pattern sequence
+  return 0;
 }
 
 SongFileLoader::ret_t SongFileLoader::load(SDL_RWops *file)
@@ -358,6 +359,7 @@ int SongFileLoader::loadOld(SDL_RWops *file)
     patseq.patterns[patseq.sequence[i]].used++;
     patseq.num_entries++;
   }
+  return 0;
 }
 
 size_t read_str_from_file(SDL_RWops *file, char *str_ptr, int size)

--- a/pc/tracker/SongSettings.cpp
+++ b/pc/tracker/SongSettings.cpp
@@ -207,6 +207,7 @@ size_t SongSettingsChunkLoader::load(SDL_RWops *file, size_t chunksize)
       maxread += subchunksize;
     }
   }
+  return maxread;
 }
 
 size_t SongSettingsChunkLoader::save(SDL_RWops *file)
@@ -271,6 +272,7 @@ size_t SongSettingsChunkLoader::save(SDL_RWops *file)
   SDL_RWwrite(file, &chunklen, 2, 1);
 
   SDL_RWseek(file, chunkend_location, RW_SEEK_SET);
+  return 0;
 }
 
 /* OF course I am aware of the repetitive nature of this code impl. But
@@ -393,6 +395,7 @@ int SongSettingsPanel::handle_event(const SDL_Event &ev)
 
   efb_incbtn.check_event(ev);
   efb_decbtn.check_event(ev);
+  return 0;
 }
 
 void SongSettingsPanel::draw(SDL_Surface *screen/*=::render->screen*/)
@@ -436,6 +439,7 @@ int SongSettingsPanel::inc_mvol(void *i)
     ::player->spc_write_dsp(dsp_reg::mvol_r, mvol);
     tracker->apuram->mvol_val = mvol;
   }
+	return 0;
 }
 
 int SongSettingsPanel::dec_mvol(void *i)
@@ -451,6 +455,7 @@ int SongSettingsPanel::dec_mvol(void *i)
     ::player->spc_write_dsp(dsp_reg::mvol_r, mvol);
     tracker->apuram->mvol_val = mvol;
   }
+  return 0;
 }
 
 int SongSettingsPanel::inc_evol(void *i)
@@ -466,6 +471,7 @@ int SongSettingsPanel::inc_evol(void *i)
     ::player->spc_write_dsp(dsp_reg::evol_r, evol);
     tracker->apuram->evol_val = evol;
   }
+  return 0;
 }
 
 int SongSettingsPanel::dec_evol(void *i)
@@ -481,6 +487,7 @@ int SongSettingsPanel::dec_evol(void *i)
     ::player->spc_write_dsp(dsp_reg::evol_r, evol);
     tracker->apuram->evol_val = evol;
   }
+  return 0;
 }
 
 int SongSettingsPanel::inc_edl(void *i)
@@ -502,6 +509,7 @@ int SongSettingsPanel::inc_edl(void *i)
     tracker->apuram->esa_val = esa;
     tracker->apuram->edl_val = edl;
   }
+  return 0;
 }
 
 int SongSettingsPanel::dec_edl(void *i)
@@ -532,6 +540,7 @@ int SongSettingsPanel::dec_edl(void *i)
     tracker->apuram->edl_val = edl;
     tracker->apuram->esa_val = esa;
   }
+  return 0;
 }
 
 int SongSettingsPanel::inc_efb(void *i)
@@ -546,6 +555,7 @@ int SongSettingsPanel::inc_efb(void *i)
     ::player->spc_write_dsp(dsp_reg::efb, efb);
     tracker->apuram->efb_val = efb;
   }
+  return 0;
 }
 
 int SongSettingsPanel::dec_efb(void *i)
@@ -560,4 +570,5 @@ int SongSettingsPanel::dec_efb(void *i)
     ::player->spc_write_dsp(dsp_reg::efb, efb);
     tracker->apuram->efb_val = efb;
   }
+  return 0;
 }

--- a/pc/tracker/content_areas/Main_Window.cpp
+++ b/pc/tracker/content_areas/Main_Window.cpp
@@ -258,6 +258,7 @@ int Main_Window::toggle_instreditor(void *m)
     if (mw->instreditor.tabs.adsr.active)
       Tracker::prerenders.erase((DrawRenderer *)&mw->instreditor.adsrpanel);
   }
+  return 0;
 }
 
 /* By and large a copy of toggle_instreditor. Maybe we can reduce code
@@ -279,6 +280,7 @@ int Main_Window::toggle_sample_editor(void *m)
 		mw->pateditpanel.set_visible_rows(0x08);
 	else
 		mw->pateditpanel.set_visible_rows(mw->pateditpanel.MAX_VISIBLE_ROWS);
+  return 0;
 }
 
 /* By and large a copy of toggle_instreditor. Maybe we can reduce code
@@ -300,6 +302,7 @@ int Main_Window::toggle_songsettings(void *m)
     mw->pateditpanel.set_visible_rows(0x08);
   else
     mw->pateditpanel.set_visible_rows(mw->pateditpanel.MAX_VISIBLE_ROWS);
+  return 0;
 }
 
 int Main_Window::Gain::change(void *dblnewgain)
@@ -519,6 +522,7 @@ int Main_Window::receive_event(SDL_Event &ev)
   default:
     break;
   }
+  return 0;
 }
 
 void Main_Window::run()


### PR DESCRIPTION
This is related to #125. However, the focus here is more narrow.

Only a void function is allowed to have a return statement: otherwise, the warning can prove to be fatal post-compilation as the routine runs past the end of the code into some other undefined territory.

This commit should resolve every single instance of the warning "control may reach end of non-void function" (whether it always/sometimes does so or not).

These days the warning in question is known as "non-void function does not return a value", or "non-void function should return a value", depending on the context.

This merge request references #32.